### PR TITLE
Service worker

### DIFF
--- a/config/eleventy.config.js
+++ b/config/eleventy.config.js
@@ -16,6 +16,7 @@ module.exports = function(eleventyConfig) {
   });
 
   eleventyConfig.addPassthroughCopy("src/icons");
+  eleventyConfig.addPassthroughCopy("src/sw.js");
 
   return {
     templateFormats: [

--- a/src/_includes/assets/app.css
+++ b/src/_includes/assets/app.css
@@ -105,6 +105,7 @@ svg {
   list-style: none;
   display: flex;
   flex-flow: row wrap;
+  max-width: 100vw;
   margin: 0 calc(-0.5 * var(--grid-gutter-size)) calc(-1 * var(--grid-gutter-size));
 }
 

--- a/src/_includes/components/footer.njk
+++ b/src/_includes/components/footer.njk
@@ -1,6 +1,6 @@
 <footer class="c-footer">
   <a href="/">Home</a>
-  <a href="/code-of-conduct">Code of Conduct</a>
-  <!-- <a href="/styleguide">Styleguide</a> -->
+  <a href="/code-of-conduct/">Code of Conduct</a>
+  <!-- <a href="/styleguide/">Styleguide</a> -->
   <a href="https://github.com/alexcarpenter/frontend-foundations/tree/master/{{ page.inputPath }}">Edit this page on GitHub</a>
 </footer>

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -27,5 +27,12 @@
   {% include "components/footer.njk" %}
   {% set js %}{% include "assets/app.js" %}{% endset %}
   <script>{{ js | jsmin | safe }}</script>
+  <script>
+    if (navigator.serviceWorker) {
+      navigator.serviceWorker.register('/sw.js', {
+        scope: '/'
+      });
+    }
+  </script>
 </body>
 </html>

--- a/src/_pages/offline.md
+++ b/src/_pages/offline.md
@@ -6,7 +6,7 @@ permalink: /offline/index.html
 
 Looks like you're offline!
 
-Not worry, the main pages of our site are still available:
+Not to worry, the main pages of our site are still available, along with any you've previously visited:
 
 - [Home](/)
 - [Code of Conduct](/code-of-conduct/)

--- a/src/_pages/offline.md
+++ b/src/_pages/offline.md
@@ -1,0 +1,12 @@
+---
+layout: page.njk
+title: Offline
+permalink: /offline/index.html
+---
+
+Looks like you're offline!
+
+Not worry, the main pages of our site are still available:
+
+- [Home](/)
+- [Code of Conduct](/code-of-conduct/)

--- a/src/icons/manifest.json
+++ b/src/icons/manifest.json
@@ -1,20 +1,21 @@
 {
+    "lang": "en",
     "name": "Front-end Foundations",
     "short_name": "FF",
     "icons": [
         {
-            "src": "/android-chrome-192x192.png",
+            "src": "/icons/android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/android-chrome-512x512.png",
+            "src": "/icons/android-chrome-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
         }
     ],
-    "theme_color": "#397DFB",
-    "background_color": "#ffffff",
     "start_url": "/",
-    "display": "minimal-ui"
+    "display": "minimal-ui",
+    "background_color": "#ffffff",
+    "theme_color": "#397dfb"
 }

--- a/src/icons/manifest.json
+++ b/src/icons/manifest.json
@@ -13,7 +13,8 @@
             "type": "image/png"
         }
     ],
-    "theme_color": "#ffffff",
+    "theme_color": "#397DFB",
     "background_color": "#ffffff",
-    "display": "standalone"
+    "start_url": "/",
+    "display": "minimal-ui"
 }

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,0 +1,72 @@
+/*
+This is a modified version of Ethan Marcotte's service worker (https://ethanmarcotte.com/theworkerofservices.js),
+which is in turn a modified version of Jeremy Keith's service worker (https://adactio.com/serviceworker.js),
+with a few additional edits borrowed from Filament Group's. (https://www.filamentgroup.com/sw.js)
+*/
+
+(function() {
+  const version = 'v1';
+  const cacheName = version + ':frontend-foundations:';
+
+  const STATIC = cacheName + 'static';
+  const PAGES = cacheName + 'pages';
+
+  const staticAssets = [
+    '/',
+    '/offline/',
+    '/code-of-conduct/'
+  ];
+
+  function updateStatic() {
+    return caches.open(STATIC)
+    .then(cache => {
+      return cache.addAll(staticAssets.map(url => new Request(url, {credentials: 'include'})));
+    });
+  }
+
+  function clearCaches() {
+    return caches.keys()
+    .then(keys => {
+      return Promise.all(keys
+        .filter(key => key.indexOf(version) !== 0)
+        .map(key => caches.delete(key))
+       );
+    });
+  }
+
+  self.addEventListener('install', event => {
+    event.waitUntil(updateStatic()
+      .then(() => self.skipWaiting())
+     );
+  });
+
+  self.addEventListener('activate', event => {
+    event.waitUntil(clearCaches()
+      .then(() => self.clients.claim())
+     );
+  });
+
+  self.addEventListener('fetch', event => {
+    const request = event.request;
+    const url = new URL(request.url);
+
+    if (request.method !== 'GET') return;
+
+    if (request.headers.get('Accept').includes('text/html')) {
+      event.respondWith(
+        fetch(request)
+          .then(response => {
+            let copy = response.clone();
+            caches.open(staticAssets.includes(url.pathname) ? STATIC : PAGES).then(cache => cache.put(request, copy));
+            return response;
+          })
+          .catch( () => {
+            return caches.match(request)
+              .then( response => response || caches.match('/offline/') );
+          })
+      );
+      return;
+    }
+
+  });
+})();


### PR DESCRIPTION
I've modified a Service Worker I've used before on static sites. It's network-first, cache-fallback so it'll work offline, but still get instant content updates without breaking Netlify's cache invalidation. Given all assets are inlined at this stage, this method works well. The main downside is that shaky network conditions will still affect this site, but as it's only `html` for now, it's not a big deal.

There's a new offline page that lists the key pages. I've also added a trailing slash to the footer links. Netlify auto-redirects `/code-of-conduct` to `/code-of-conduct/` so that would count as separate URLs in the service worker. Plus skipping the redirect will improve performance.

Future ideas for the SW could include:

- Dedicated image cache
- Cache trimming
- Form submit prevention
- Cache-first strategy for non-html assets